### PR TITLE
Add URL and BugReports links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,3 +16,5 @@ SystemRequirements: GNU make
 Suggests: 
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+URL: https://github.com/fdaPDE/fdaPDE-R
+BugReports: https://github.com/fdaPDE/fdaPDE-R/issues


### PR DESCRIPTION
Dear all, 

as reported in the [R Exts Manual](https://cran.r-project.org/doc/manuals/r-release/R-exts.html), the DESCRIPTION file of an R package may include two fields named `URL` and `BugReports` detailing 1) a list of URLs where additional material describing the software can be found and 2) a single URL to which bug reports about the package should be submitted. If present, these fields are listed in the CRAN page of the package (see [here](https://cran.r-project.org/web/packages/Rcpp/index.html) for example). 

I created this PR adding these two fields since, IMO, they are really simple to maintain and greatly ease the user experience! 